### PR TITLE
made fixes for missing returnUrl value, and it's use if the identity …

### DIFF
--- a/src/Controllers/AccountController.cs
+++ b/src/Controllers/AccountController.cs
@@ -1471,7 +1471,7 @@ namespace Bastille.Id.Server.Controllers
             var vm = new LoggedOutViewModel
             {
                 AutomaticRedirectAfterSignOut = this.Context.Settings.Account.AutomaticRedirectAfterSignOut,
-                PostLogoutRedirectUri = logout?.PostLogoutRedirectUri,
+                PostLogoutRedirectUri = logout?.PostLogoutRedirectUri ?? model.ReturnUrl,
                 ClientName = string.IsNullOrEmpty(logout?.ClientName) ? logout?.ClientId : logout?.ClientName,
                 SignOutIframeUrl = logout?.SignOutIFrameUrl,
                 LogoutId = model.LogoutId,

--- a/src/Views/Account/Logout.cshtml
+++ b/src/Views/Account/Logout.cshtml
@@ -12,6 +12,7 @@
             {
                 <form asp-action="Logout">
                     <input type="hidden" asp-for="LogoutId" />
+                    <input type="hidden" asp-for="ReturnUrl" />
                     @await Html.PartialAsync("_ValidationSummary")
                     @if (Model.ShowLogoutPrompt)
                     {


### PR DESCRIPTION
Resolve #6 by using the ReturnUrl from the logout confirmation form. If the client does not have a defined logout redirect URI. this value will be used instead. In the case of logging into the Identity interface, this will return to the login page form after logout.